### PR TITLE
create directories with at least user read mode set

### DIFF
--- a/u9fs.c
+++ b/u9fs.c
@@ -1648,7 +1648,7 @@ usercreate(Fid *fid, char *elem, int omode, long perm, char **ep)
 			return -1;
 		}
 		/* race */
-		if(mkdir(npath, perm&0777) < 0){
+		if(mkdir(npath, perm&0777|0400) < 0){
 			*ep = strerror(errno);
 			free(npath);
 			return -1;


### PR DESCRIPTION
When replica/applylog creates directories it does so by issuing create(name, DMDIR) followed by dirwstat() to set the actual mode. Plan 9 file servers are fine with that; u9fs is not, however: it implements such a create through mkdir followed by opendir, and the later fails if the mode doesn't allow reads. The simple fix is to enforce the user-read bit in the mkdir call.